### PR TITLE
fix: set failure on no token

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,4 +84,7 @@ async function fetchFromDomain(fetchDomain) {
             console.log(`::error::failed to get token from ${domain}: ${err.stack}`);
         }
     }
+
+    console.log(`::error::Failed to get a token`);
+    process.exit(1);
 })();


### PR DESCRIPTION
Currently the action succeeds even when no token request were successful.